### PR TITLE
:up: Update dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN set -ex; \
 ##### pgpool2
 FROM alpine:3.6
 ENV PGPOOL_VERSION 3.6.7
-ENV PG_VERSION 9.6.5-r0
+ENV PG_VERSION 9.6.6-r0
 ENV LANG en_US.utf8
 COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 RUN apk --update --no-cache --virtual .build-deps add \


### PR DESCRIPTION
alpine linuxのpkgからpostgresql-dev=9.6.5-r0が無くなってるようで、buildに失敗するようでした。

このpull reqで postgresql-devのversionを上げてこの問題を修正します